### PR TITLE
build: automate building

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -11,9 +11,13 @@ name: Check Transpiled JavaScript
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   check-dist:
@@ -22,6 +26,7 @@ jobs:
 
     permissions:
       contents: read
+      pull-requests: write
       statuses: write
 
     steps:
@@ -40,39 +45,20 @@ jobs:
         id: install
         run: npm ci
 
-      - name: Execute all required jobs
-        id: run-all
+      - name: Build dist/ Directory
+        id: build
         run: npm run all
-
-      - name: Commit & Push changes
-        id: commit-and-push
-        run: |
-          changes=$(git diff --ignore-space-at-eol --text | wc -l)
-          if [[ -n "$changes" && "$changes" -gt "0" ]]; then
-            echo "found changes, committing and pushing"
-            git add .
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore: files changed with npm run all"
-            git push
-          fi
 
       # This will fail the workflow if the PR wasn't created by Dependabot.
       - name: Compare Directories
         id: diff
         run: |
-          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build. See status below:"
-            git diff --ignore-space-at-eol --text dist/
-            exit 1
+          changedFiles=$(git diff --ignore-space-at-eol --text | wc -l)
+          if [[ -n "$changes" && "$changes" -gt "0" ]]; then
+            echo "committing and pushing changes"
+            git add .
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: automatic build changes"
+            git push
           fi
-
-      # If `dist/` was different than expected, and this was not a Dependabot
-      # PR, upload the expected version as a workflow artifact.
-      - if: ${{ failure() && steps.diff.outcome == 'failure' }}
-        name: Upload Artifact
-        id: upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -178,11 +178,11 @@ describe('action', () => {
     expect(refWidget.iconUrl).toContain('ref.png');
     expect(refWidget.buttonText).toBeFalsy();
 
-    const worfkflowWidget = getWorkflowWidget(card);
-    expect(worfkflowWidget.label).toContain('Workflow');
-    expect(worfkflowWidget.text).toContain(workflow);
-    expect(worfkflowWidget.iconUrl).toContain('event_workflow_dispatch.png');
-    expect(worfkflowWidget.buttonText).toBeFalsy();
+    const workflowWidget = getWorkflowWidget(card);
+    expect(workflowWidget.label).toContain('Workflow');
+    expect(workflowWidget.text).toContain(workflow);
+    expect(workflowWidget.iconUrl).toContain('event_workflow_dispatch.png');
+    expect(workflowWidget.buttonText).toBeFalsy();
 
     const actorWidget = getActorWidget(card);
     expect(actorWidget.label).toContain('Actor');


### PR DESCRIPTION
instead of requiring a user to run build and generate dist and data and verifying that it was performed, do it for the user and push if anything changed.