### PR TITLE
ci: fix check-dist build and add Dependabot auto-merge

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build dist/ Directory
         id: build
-        run: npm run all
+        run: npm run package
 
       - name: Check for changes
         id: changes
@@ -59,7 +59,7 @@ jobs:
 
       - name: Commit & Push changes
         id: commit-push
-        if: ${{success() && env.CHANGES=='true'}}
+        if: ${{success() && env.CHANGES=='true' && github.ref == 'refs/heads/main'}}
         run: |
           # generate key to sign commit
           mkdir -p /tmp/key

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

`Check dist/` has failed on every branch since ~June 1: `npm run all` runs an `svg` step (svgexport → puppeteer) that needs Chrome, which the hosted runner no longer provides. Because `svg` runs before `package`, the job dies before `dist/` is ever rebuilt — which also broke the automatic `dist/` rebuild-and-commit on `main`. There is no auto-merge for Dependabot PRs.

## Changes

**`check-dist.yml`**
- Build with `npm run package` (pure rollup) instead of `npm run all`. The workflow's only job is to verify `dist/`; lint/test already run in `ci.yml`, and the browser-based `svg` doc-asset step is unrelated. Reproduces the committed `dist/` exactly on locked deps.
- Only auto-commit the rebuilt `dist/` on `main` (`github.ref == 'refs/heads/main'`). On a PR branch, a `GITHUB_TOKEN` commit does not re-trigger the required `ci.yml` checks, which would stall native auto-merge. `main` self-heals `dist/` after each merge, as before.

**`dependabot-auto-merge.yml`** (new)
- Enables GitHub native auto-merge for Dependabot PRs, **excluding major version bumps** (left for manual review). Merges once the required checks (`JavaScript Tests`, `GitHub Actions Test`) pass. Uses squash to match existing history.

## Notes
- `svgexport`/`puppeteer` (the doc-PNG generation) is intentionally left untouched here — separate follow-up.
- Existing open Dependabot PRs need a rebase to pick up the fixed `check-dist` workflow before their checks go green.