### PR TITLE
ci: push auto-built dist via deploy key (enables runtime-dep auto-merge)

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -57,21 +57,24 @@ jobs:
             echo "no changes"
           fi
 
-      # Push the rebuilt dist/ to the source branch; main is protected and
+      # Push the rebuilt dist/ to the source branch via the deploy key. Pushing
+      # with a deploy key (not GITHUB_TOKEN) re-triggers CI on the new commit, so
+      # required checks re-run and auto-merge can proceed. main is protected and
       # rejects direct pushes, so it is resynced via the merged PR instead.
       - name: Commit & Push changes
         id: commit-push
         if: ${{success() && env.CHANGES=='true' && github.ref != 'refs/heads/main'}}
+        env:
+          DEPLOY_KEY: ${{ secrets.DIST_DEPLOY_KEY }}
         run: |
-          # generate key to sign commit
-          mkdir -p /tmp/key
-          ssh-keygen -t ed25519 -C 'github-actions[bot]@users.noreply.github.com' -f /tmp/key/id_ed25519 -N ''
-          git add .
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/dist_deploy_key
+          chmod 600 ~/.ssh/dist_deploy_key
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/dist_deploy_key -o StrictHostKeyChecking=accept-new"
+          git remote set-url origin "git@github.com:${{ github.repository }}.git"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.signingkey '/tmp/key/id_ed25519'
-          git config gpg.format ssh
-          git config commit.gpgsign true
+          git add .
           git commit -m "chore: automatic build changes"
-          git push
-          rm -rf /tmp/key
+          git push origin "HEAD:${{ github.ref_name }}"
+          rm -f ~/.ssh/dist_deploy_key


### PR DESCRIPTION
## Why

Dev-dependency PRs auto-merge fine because they don't change `dist/`. **Runtime-dependency** PRs (axios, etc.) do change `dist/`: `check-dist` rebuilds it and commits to the PR branch, but that commit is pushed with `GITHUB_TOKEN`, which **does not start new workflow runs**. So the required checks (`JavaScript Tests`, `GitHub Actions Test`) never re-run on the new head, branch protection keeps blocking, and native auto-merge stalls.

## Change

`check-dist` now pushes the rebuilt `dist/` using a dedicated **`dist-auto-build` deploy key** (private key in the `DIST_DEPLOY_KEY` Actions + Dependabot secret) instead of `GITHUB_TOKEN`. A deploy-key push re-triggers CI on the new commit, the required checks pass on the new head, and auto-merge completes — `dist/` and the dependency bump land together.

The key is referenced only by the push step (not during `npm ci`/build), and only runs on source branches (never protected `main`).

## Notes
- Self-terminating: the pushed `dist/` commit re-runs `check-dist`, which finds `dist/` already in sync → no further commit.
- Dropped the unverified ephemeral-key commit signing (signatures aren't required by branch protection).