### PR TITLE
ci: only run check-dist on branch pushes, not tags

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -11,6 +11,8 @@ name: Check Transpiled JavaScript
 
 on:
   push:
+    branches:
+      - '**'
 
 permissions:
   contents: write


### PR DESCRIPTION
Bare `on: push` triggered check-dist on tag pushes too, which re-ran old tags' workflows (e.g. the v1.1.0 tag's failing svgexport run). Scope the trigger to branch pushes (`branches: ['**']` still matches Dependabot's slashed branches; main and feature branches unaffected). Tags no longer trigger check-dist.